### PR TITLE
switch to python3.10 for release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -15,7 +15,7 @@ jobs:
         id: build_package
         run: |
           sudo apt-get update && \
-          sudo apt-get install -yq --no-install-recommends python3-pip python3.7 python3-dev python3-setuptools && \
+          sudo apt-get install -yq --no-install-recommends python3-pip python3 python3-dev python3-setuptools && \
           pip3 install wheel && \
           python3 setup.py sdist bdist_wheel --universal
         if: github.repository == 'iqtlabs/daisybell' && github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10, 3.11]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10, 3.11]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
python3.7 was deprecated as of 12-06-2022. the package is no longer maintained. switch to using system python3, which evaluates to the 3.10.x line instead