### PR TITLE
Plugin doc

### DIFF
--- a/daisybell/daisybell.py
+++ b/daisybell/daisybell.py
@@ -19,7 +19,6 @@ def scan(model: Pipeline, params: dict = {}) -> Generator:
         A (name, kind, description, {output}) tuple of all scanners that are applicable to the model.
     """
 
-    formatter = logging.Formatter(logging.BASIC_FORMAT)
     root_logger = logging.getLogger("daisybell")
     root_logger.setLevel(os.environ.get("LOGLEVEL", "INFO"))
 

--- a/daisybell/daisybell.py
+++ b/daisybell/daisybell.py
@@ -19,13 +19,9 @@ def scan(model: Pipeline, params: dict = {}) -> Generator:
         A (name, kind, description, {output}) tuple of all scanners that are applicable to the model.
     """
 
-    handler = logging.handlers.WatchedFileHandler(
-        os.environ.get("LOGFILE", "./daisybell.log"))
     formatter = logging.Formatter(logging.BASIC_FORMAT)
-    handler.setFormatter(formatter)
-    root_logger = logging.getLogger()
+    root_logger = logging.getLogger("daisybell")
     root_logger.setLevel(os.environ.get("LOGLEVEL", "INFO"))
-    root_logger.addHandler(handler)
 
     for scanner_class in ScannerRegistry.registered_scanners:
         scanner = scanner_class(root_logger)

--- a/daisybell/scanners/README.md
+++ b/daisybell/scanners/README.md
@@ -1,0 +1,43 @@
+# Daisybell Scanners
+All scanners are implemented as plugins to the Diasybell system. The system maintains a registry of known local plugins and upon being called against a given [Pipeline](https://huggingface.co/docs/transformers/main_classes/pipelines) will iterate across all registered scanners. If a scanner is capable of scanning a given pipeline (typically based on it's type or task) then that scanner's `scan` method will be invoked and the results of said scan will be returned.
+
+# Current Scanners
+## MaskingLanguageBias
+**Kind:** bias
+**Tasks:** fill-mask
+**Description:** 
+Scans for language bias in NLP masking models.
+
+## NerLanguageBias
+**Kind:** bias
+**Tasks:** token-classification
+**Description:** 
+Scans for language bias in NER based models. WARNING! THIS SCANNER IS EXPERIMENTAL.
+
+## ZeroShotLanguageBias
+**Kind:** bias
+**Tasks:** zero-shot-classification
+**Description:** 
+Scans for language bias in NLP zero shot models.
+
+# Adding new Scanners
+To add a new scanner create a class that inherits from `daisybell.scanners.ScannerBase`. We suggest adding it in the `daisybell/scanners` directory in order to make it easier to track however the location shouldn't matter. Loading the class into memory will automatically add the new scanner to the ScannerRegistry. For examples please look to the classes within the `daisybell.scanners` module. To execute properly your scanner class must implement the following methods:
+### `__init__`
+**Parameters:** None
+**Returns:** None
+This method will initialize any values that need to be set for the class to execut a successful scan. The first line of this scan must be:
+`super().__init__(<NAME>, <KIND>, <DESCRIPTION>, logger)`
+If this call is not made then the scanner will not be added to the `ScannerRegistry` and will not be called by subsequent `daisybell` scans.
+
+### `can_scan`
+**Parameters:** 
+pipeline: an instance of transformers.Pipeline
+**Returns:** bool
+This method should return True if the `scan` method is applicable to the supplied Pipeline, otherwise False
+
+### `scan`
+**Parameters:** 
+pipeline: an instance of transformers.Pipeline
+params: a ditionary of parameters to be supplied to the pipeline
+**Returns:** a pandas DataFrame
+This method should encapsulate the desired test routine(s) to be run against the supplied pipeline and evaluated using the supplied params. 

--- a/daisybell/scanners/README.md
+++ b/daisybell/scanners/README.md
@@ -1,5 +1,5 @@
 # Daisybell Scanners
-All scanners are implemented as plugins to the Diasybell system. The system maintains a registry of known local plugins and upon being called against a given [Pipeline](https://huggingface.co/docs/transformers/main_classes/pipelines) will iterate across all registered scanners. If a scanner is capable of scanning a given pipeline (typically based on it's type or task) then that scanner's `scan` method will be invoked and the results of said scan will be returned.
+All scanners are implemented as plugins to the Daisybell system. The system maintains a registry of known local plugins and upon being called against a given [Pipeline](https://huggingface.co/docs/transformers/main_classes/pipelines) will iterate across all registered scanners. If a scanner is capable of scanning a given pipeline (typically based on it's type or task) then that scanner's `scan` method will be invoked and the results of said scan will be returned.
 
 # Current Scanners
 ## MaskingLanguageBias

--- a/daisybell/scanners/scanner.py
+++ b/daisybell/scanners/scanner.py
@@ -22,9 +22,7 @@ class ScannerBase(metaclass=ScannerRegistry):
         self.logger = logger
 
     def can_scan(self, model: Pipeline) -> bool:
-        self.logger.warning('Base class can_scan should not be directly invoked')
-        return False
+        raise NotImplementedError('Base class can_scan should not be directly invoked')
 
     def scan(self, model: Pipeline, params: dict) -> pd.DataFrame:
-        self.logger.warning('Base class scan should not be directly invoked')
-        return None
+        raise NotImplementedError('Base class scan should not be directly invoked')

--- a/tests/test_scannerbase.py
+++ b/tests/test_scannerbase.py
@@ -1,0 +1,24 @@
+import logging
+import pytest
+
+from daisybell.scanners import ScannerBase, ScannerRegistry
+
+@pytest.fixture
+def invalid_scanner():
+
+    class InvalidScanner(ScannerBase):
+        def __init__(self, logger: logging.Logger):
+            super().__init__("InvalidScanner", "invalid", "Scanner to test for correct behavior to base class when dealing with improper inheitance", logger)
+
+    logger = logging.getLogger("daisybell-test")
+    invalid = InvalidScanner(logger)
+    yield invalid
+
+def test_base_can_scan(invalid_scanner):
+    with pytest.raises(NotImplementedError):
+        invalid_scanner.can_scan("fakemodel")
+
+def test_base_scan(invalid_scanner):
+    with pytest.raises(NotImplementedError):
+        invalid_scanner.scan("fakemodel", {})
+        

--- a/tests/test_scannerbase.py
+++ b/tests/test_scannerbase.py
@@ -3,22 +3,31 @@ import pytest
 
 from daisybell.scanners import ScannerBase, ScannerRegistry
 
+
 @pytest.fixture
 def invalid_scanner():
 
     class InvalidScanner(ScannerBase):
         def __init__(self, logger: logging.Logger):
-            super().__init__("InvalidScanner", "invalid", "Scanner to test for correct behavior to base class when dealing with improper inheitance", logger)
+            super().__init__("InvalidScanner", "invalid",
+                             "Scanner to test for correct behavior to base class when dealing with improper inheitance",
+                             logger)
 
     logger = logging.getLogger("daisybell-test")
     invalid = InvalidScanner(logger)
     yield invalid
 
+
 def test_base_can_scan(invalid_scanner):
     with pytest.raises(NotImplementedError):
         invalid_scanner.can_scan("fakemodel")
 
+
 def test_base_scan(invalid_scanner):
     with pytest.raises(NotImplementedError):
         invalid_scanner.scan("fakemodel", {})
-        
+
+
+def test_ScannerRegistry(invalid_scanner):
+    min_scanners = 4  # 3 basic scanners + InvalidScanner
+    assert len(ScannerRegistry.registered_scanners) >= min_scanners


### PR DESCRIPTION
- switches from Warning to NotImplementedError in the case that a scanner falls through into the base class
- refactored logging to be more consistent with things like systemd
- added unit tests for ScannerBase
- added README to document plugin structure for scanners